### PR TITLE
Fix recursive include for MinGW on case-insensitive filesystems

### DIFF
--- a/include/mingw-fixes/IPHlpApi.h
+++ b/include/mingw-fixes/IPHlpApi.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_IPHLPAPI_H
+#define __MINGW_FIXES_IPHLPAPI_H
+
 #include <iphlpapi.h>
+
+#ifdef __MINGW_FIXES_IPHLPAPI_H_AGAIN
+#include_next <iphlpapi.h>
+#endif
+
+#else
+#define __MINGW_FIXES_IPHLPAPI_H_AGAIN
+#endif

--- a/include/mingw-fixes/Ifdef.h
+++ b/include/mingw-fixes/Ifdef.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_IFDEF_H
+#define __MINGW_FIXES_IFDEF_H
+
 #include <ifdef.h>
+
+#ifdef __MINGW_FIXES_IFDEF_H_AGAIN
+#include_next <ifdef.h>
+#endif
+
+#else
+#define __MINGW_FIXES_IFDEF_H_AGAIN
+#endif

--- a/include/mingw-fixes/ShlObj.h
+++ b/include/mingw-fixes/ShlObj.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_SHLOBJ_H
+#define __MINGW_FIXES_SHLOBJ_H
+
 #include <shlobj.h>
+
+#ifdef __MINGW_FIXES_SHLOBJ_H_AGAIN
+#include_next <shlobj.h>
+#endif
+
+#else
+#define __MINGW_FIXES_SHLOBJ_H_AGAIN
+#endif

--- a/include/mingw-fixes/Shlwapi.h
+++ b/include/mingw-fixes/Shlwapi.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_SHLWAPI_H
+#define __MINGW_FIXES_SHLWAPI_H
+
 #include <shlwapi.h>
+
+#ifdef __MINGW_FIXES_SHLWAPI_H_AGAIN
+#include_next <shlwapi.h>
+#endif
+
+#else
+#define __MINGW_FIXES_SHLWAPI_H_AGAIN
+#endif

--- a/include/mingw-fixes/Synchapi.h
+++ b/include/mingw-fixes/Synchapi.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_SYNCHAPI_H
+#define __MINGW_FIXES_SYNCHAPI_H
+
 #include <synchapi.h>
+
+#ifdef __MINGW_FIXES_SYNCHAPI_H_AGAIN
+#include_next <synchapi.h>
+#endif
+
+#else
+#define __MINGW_FIXES_SYNCHAPI_H_AGAIN
+#endif

--- a/include/mingw-fixes/WS2tcpip.h
+++ b/include/mingw-fixes/WS2tcpip.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_WS2TCPIP_H
+#define __MINGW_FIXES_WS2TCPIP_H
+
 #include <ws2tcpip.h>
+
+#ifdef __MINGW_FIXES_WS2TCPIP_H_AGAIN
+#include_next <ws2tcpip.h>
+#endif
+
+#else
+#define __MINGW_FIXES_WS2TCPIP_H_AGAIN
+#endif

--- a/include/mingw-fixes/WinSock2.h
+++ b/include/mingw-fixes/WinSock2.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_WINSOCK2_H
+#define __MINGW_FIXES_WINSOCK2_H
+
 #include <winsock2.h>
+
+#ifdef __MINGW_FIXES_WINSOCK2_H_AGAIN
+#include_next <winsock2.h>
+#endif
+
+#else
+#define __MINGW_FIXES_WINSOCK2_H_AGAIN
+#endif

--- a/include/mingw-fixes/Windows.h
+++ b/include/mingw-fixes/Windows.h
@@ -1,1 +1,12 @@
+#ifndef __MINGW_FIXES_WINDOWS_H
+#define __MINGW_FIXES_WINDOWS_H
+
 #include <windows.h>
+
+#ifdef __MINGW_FIXES_WINDOWS_H_AGAIN
+#include_next <windows.h>
+#endif
+
+#else
+#define __MINGW_FIXES_WINDOWS_H_AGAIN
+#endif


### PR DESCRIPTION
This simply makes use of include guards and the `#include_next` directive to prevent recursive includes on case-insensitive filesystems introduced by the headers in the `mingw-fixes` directory.

This pattern may seem unnecessarily complicated so I'll provide additional explanation. Even in the case where the `mingw-fixes` directory is located on a case-insensitive filesystem, the target header could be located in a directory on a case-sensitive filesystem found earlier in the search path. Therefore, the `#include` checks the full search path for the header with the correct casing. The `#include_next` directive should only be reached if the header includes itself due to a case-insensitive match.