### PR TITLE
Set SOCKLEN_T_DEFINED for Android builds on Linux

### DIFF
--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -55,12 +55,12 @@
 #if __ANDROID__
 #define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS 0
 #endif
-//#if __ANDROID__
-////#define LWIP_PROVIDE_ERRNO              0
-//#define SOCKLEN_T_DEFINED
-//#elif !defined(_MSC_VER)
-//#define LWIP_PROVIDE_ERRNO              1
-//#endif
+#if __ANDROID__
+//#define LWIP_PROVIDE_ERRNO              0
+#define SOCKLEN_T_DEFINED
+#elif !defined(_MSC_VER)
+#define LWIP_PROVIDE_ERRNO              1
+#endif
 #define LWIP_ERRNO_STDINCLUDE 1
 // Sockets
 #define LWIP_SOCKET                     1


### PR DESCRIPTION
It looks like both Linux and Windows define `socklen_t` in system headers, but Linux must use a different type than Windows and lwIP which would cause [the error in CI](https://app.circleci.com/pipelines/github/diasurgical/devilutionX/9069/workflows/7661e5cb-bc3a-4f20-9165-cc673c0e545e/jobs/64582). Reintroducing this commented code from `lwipopts.h` should fix the issue.

I'm not sure why this was commented in the first place. It seems like the mainline libzt maintainers have gone back and forth on this. The current version of their codebase has it uncommented so it should be okay.
https://github.com/zerotier/libzt/blob/20e20be0f3436bc2a859b79efae884a68293d452/src/lwipopts.h#L57-L62

@AJenbo 