### PR TITLE
Disable LWIP_PROVIDE_ERRNO

### DIFF
--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -58,8 +58,8 @@
 #if __ANDROID__
 //#define LWIP_PROVIDE_ERRNO              0
 #define SOCKLEN_T_DEFINED
-#elif !defined(_MSC_VER)
-#define LWIP_PROVIDE_ERRNO              1
+//#elif !defined(_MSC_VER)
+//#define LWIP_PROVIDE_ERRNO              1
 #endif
 #define LWIP_ERRNO_STDINCLUDE 1
 // Sockets


### PR DESCRIPTION
To fix the following error...
```
/home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/lwip/src/include/lwip/errno.h:47:2: error: #error "This fork does not support configurations with LWIP_PROVIDE_ERRNO"
 #error "This fork does not support configurations with LWIP_PROVIDE_ERRNO"
  ^~~~~
```