### PR TITLE
Disable building of the examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,11 @@ endif ()
 if (BUILDING_WIN32 OR BUILDING_WIN64 OR MSVC)
 	set (BUILDING_WIN TRUE)
 endif ()
-if (NOT BUILDING_ANDROID AND NOT IN_XCODE)
-	set(SHOULD_BUILD_TESTS TRUE)
-endif ()
 if (BUILDING_WIN32 OR BUILDING_WIN64 OR MSVC)
 	set (BUILDING_WIN TRUE)
 endif ()
+
+option(BUILD_EXAMPLES "Build the examples" OFF)
 
 # -----------------------------------------------------------------------------
 # |                                BUILD TYPES                                |
@@ -451,7 +450,7 @@ endif ()
 # |                                EXECUTABLES                                |
 # -----------------------------------------------------------------------------
 
-if (SHOULD_BUILD_TESTS)
+if (BUILD_EXAMPLES)
 	add_executable (earthtest ${PROJ_DIR}/examples/cpp/earthtest.cpp)
 	target_link_libraries(earthtest ${STATIC_LIB_NAME})
 	add_executable (adhoc ${PROJ_DIR}/examples/cpp/adhoc.cpp)


### PR DESCRIPTION
`libzt` adds build target for its examples by default.

However, the `examples/` directory is marked as `export-ignore` in libzt's
`.gitattributes`, so it does not get included into the GitHub-provided archive.

While we use a recursive git fetch (and are not affected), distributions
may override this with `-DFETCHCONTENT_SOURCE_DIR_LIBZT=...`,
where `export-ignore` files may be omitted from the source directory.

Context: Trying to package 1.3.0 for buildroot-based distributions, such as batocera.linux and RetroLX: https://github.com/RetroLX/RetroLX/pull/26