### PR TITLE
CMake: Remove global java include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,6 @@ endif()
 # ------------------------------------------------------------------------------
 # |                             INCLUDE DIRECTORIES                            |
 # ------------------------------------------------------------------------------
-# Temporary measure to test GitHub workflow on Ubuntu
-include_directories(/usr/lib/jvm/java-11-openjdk-amd64/include/linux/)
 # ZeroTier
 include_directories(${ZTO_SRC_DIR})
 include_directories(${ZTO_SRC_DIR}/include)


### PR DESCRIPTION
This broke hermetic and cross-compilation builds of libzt.

Example error (from buildroot): ERROR: unsafe header/library path used in cross-compilation: '-I/usr/lib/jvm/java-11-openjdk-amd64/include/linux'

---

This is a cherry-pick of the upstream PR https://github.com/zerotier/libzt/pull/182