### PR TITLE
Don't give up on failure to create parent directory

### DIFF
--- a/src/NodeService.cpp
+++ b/src/NodeService.cpp
@@ -220,13 +220,14 @@ NodeService::ReasonForTermination NodeService::run()
                 }
                 ptmp.append(*pi);
                 if ((*pi != ".") && (*pi != "..")) {
-                    if (OSUtils::mkdir(ptmp) == false) {
-                        Mutex::Lock _l(_termReason_m);
-                        _termReason = ONE_UNRECOVERABLE_ERROR;
-                        _fatalErrorMessage = "home path could not be created";
-                        return _termReason;
-                    }
+                    OSUtils::mkdir(ptmp);
                 }
+            }
+            if (OSUtils::mkdir(ptmp) == false) {
+                Mutex::Lock _l(_termReason_m);
+                _termReason = ONE_UNRECOVERABLE_ERROR;
+                _fatalErrorMessage = "home path could not be created";
+                return _termReason;
             }
         }
 


### PR DESCRIPTION
On systems where permissions don't allow you to check for the existence of a directory, it may still be possible to create the config directory even if `OSUtils::mkdir()` fails on a parent directory.