### PR TITLE
Add core function to query peer ID from MAC address

### DIFF
--- a/include/ZeroTierSockets.h
+++ b/include/ZeroTierSockets.h
@@ -2976,6 +2976,18 @@ ZTS_API int ZTCALL zts_core_query_route(
  *
  * @return `ZTS_ERR_OK` if successful. `ZTS_ERR_SERVICE` if the core service is unavailable.
  */
+ZTS_API int ZTCALL zts_core_query_peer_id(uint64_t net_id, uint64_t mac, uint64_t* peer_id);
+
+/**
+ * @brief Lock the core service so that queries about addresses, routes, paths, etc. can be
+ * performed.
+ *
+ * Notice: Core locking functions are intended to be used by high-level language wrappers.
+ * Only lock the core if you know *exactly* what you are doing. zts_core_lock_obtain() and
+ * zts_core_lock_release() must be called before and after this function.
+ *
+ * @return `ZTS_ERR_OK` if successful. `ZTS_ERR_SERVICE` if the core service is unavailable.
+ */
 ZTS_API int ZTCALL zts_core_query_path_count(uint64_t peer_id);
 
 /**

--- a/src/Controls.cpp
+++ b/src/Controls.cpp
@@ -396,6 +396,12 @@ int zts_core_query_route(
     return zts_service->getRouteAtIdx(net_id, idx, target, via, len, flags, metric);
 }
 
+int zts_core_query_peer_id(uint64_t net_id, uint64_t mac, uint64_t* peer_id)
+{
+    ACQUIRE_SERVICE(ZTS_ERR_SERVICE);
+    return zts_service->getPeerId(net_id, mac, peer_id);
+}
+
 int zts_core_query_path_count(uint64_t peer_id)
 {
     ACQUIRE_SERVICE(ZTS_ERR_SERVICE);

--- a/src/NodeService.hpp
+++ b/src/NodeService.hpp
@@ -293,6 +293,9 @@ class NodeService {
     /** Return number of multicast subscriptions on the network. Service must be locked. */
     int multicastSubCount(uint64_t net_id) const;
 
+    /** Return peer ID for a given MAC address. */
+    int getPeerId(uint64_t net_id, uint64_t mac, uint64_t* peerId) const;
+
     /** Return number of known physical paths to the peer. Service must be locked. */
     int pathCount(uint64_t peer_id) const;
 


### PR DESCRIPTION
Step 2 for retrieving route information for players in your DevX game session. This just exposes the peer ID using the function from https://github.com/diasurgical/ZeroTierOne/pull/2 via the `zts_core_query_peer_id()` function. Since we are marshalling the whole `ZT_Peer` struct, we could also expose more information such as latency. But peer ID is sufficient to look up route information if we hook to the `ZTS_EVENT_PEER_*` events and capture the information in a lookup table.