### PR TITLE
CMakeLists: avoid adding/compiling sources twice in static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,7 +634,7 @@ if(BUILD_STATIC_LIB)
         ${STATIC_LIB_NAME} STATIC
         $<TARGET_OBJECTS:zt_pic> $<TARGET_OBJECTS:zto_pic>
         $<TARGET_OBJECTS:natpmp_pic> $<TARGET_OBJECTS:miniupnpc_pic>
-        $<TARGET_OBJECTS:lwip_pic> ${libztSrcGlob})
+        $<TARGET_OBJECTS:lwip_pic>)
     set_target_properties(
         ${STATIC_LIB_NAME}
         PROPERTIES LINKER_LANGUAGE CXX


### PR DESCRIPTION
When compiling as static library the "main" sources (`libztSrcGlob`) are added to `zt_pic` and the static library itself.
The static library on the other hand also includes `zt_pic`. That means the code is included twice and MSVC warns about it ([LNK4006](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4006?view=msvc-170)).
This PR removes the second include/compilation.

When compiling devilutionX with MSVC and this PR the warnings gets reduced by 256 (from 691 to 435).

I only tested this with MSVC on windows.
I hope this is the correct branch. But this is the one that currently devilutionX master uses as far as I saw.

Side-Note: I'm not sure if there could be some other things be optimized (for example `ztcore` is definied in CMake but not used (as far as I noticed)). But I was happy when the warnings got reduced.

Example warnings:

>  VirtualTap.cpp.obj : warning LNK4006: "bool ZeroTier::_has_exited" (?_has_exited@ZeroTier@@3_NA) already defined in VirtualTap.cpp.obj; second definition ignored
  VirtualTap.cpp.obj : warning LNK4006: "bool ZeroTier::_has_started" (?_has_started@ZeroTier@@3_NA) already defined in VirtualTap.cpp.obj; second definition ignored
  VirtualTap.cpp.obj : warning LNK4006: "int ZeroTier::netifCount" (?netifCount@ZeroTier@@3HA) already defined in VirtualTap.cpp.obj; second definition ignored
  VirtualTap.cpp.obj : warning LNK4006: "public: __cdecl ZeroTier::VirtualTap::VirtualTap(char const *,class ZeroTier::MAC const &,unsigned int,unsigned int,unsigned __int64,void (__cdecl*)(void *,void *,unsigned __int64,class ZeroTier::MAC const &,class ZeroTier::MAC const &,unsigned int,unsigned int,void const *,unsigned int),void *)" (??0VirtualTap@ZeroTier@@QEAA@PEBDAEBVMAC@1@II_KP6AXPEAX3211IIPEBXI@Z3@Z) already defined in VirtualTap.cpp.obj; second definition ignored
  VirtualTap.cpp.obj : warning LNK4006: "public: __cdecl ZeroTier::VirtualTap::~VirtualTap(void)" (??1VirtualTap@ZeroTier@@QEAA@XZ) already defined in VirtualTap.cpp.obj; second definition ignored
  VirtualTap.cpp.obj : warning LNK4006: "public: void __cdecl ZeroTier::VirtualTap::setEnabled(bool)" (?setEnabled@VirtualTap@ZeroTier@@QEAAX_N@Z) already defined in VirtualTap.cpp.obj; second definition ignored
  VirtualTap.cpp.obj : warning LNK4006: "public: bool __cdecl ZeroTier::VirtualTap::enabled(void)const " 