### PR TITLE
Remove the LWIP_DEBUG flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,7 +398,7 @@ else()
     set(CMAKE_C_FLAGS_DEBUG
             "${CMAKE_C_FLAGS_DEBUG} \
          ${DEBUG_OPTIMIZATION} \
-         -DLWIP_DEBUG=1 -DLIBZT_DEBUG=1")
+         -DLIBZT_DEBUG=1")
 
     set(CMAKE_C_FLAGS_RELEASE
             "${CMAKE_C_FLAGS_RELEASE} \
@@ -411,7 +411,7 @@ else()
     set(CMAKE_CXX_FLAGS_DEBUG
             "${CMAKE_CXX_FLAGS_DEBUG} \
          ${DEBUG_OPTIMIZATION} \
-         -DLWIP_DEBUG=1 -DLIBZT_DEBUG=1")
+         -DLIBZT_DEBUG=1")
 
     set(CMAKE_CXX_FLAGS_RELEASE
             "${CMAKE_CXX_FLAGS_RELEASE} \


### PR DESCRIPTION
This flag is entirely too verbose.

Before:
![image](https://github.com/user-attachments/assets/9909c08a-edec-4b77-b3eb-b879ab6842cc)

After:
![image](https://github.com/user-attachments/assets/7986c3a9-1d18-4191-8ebb-9d93e0f852fe)