### PR TITLE
Raise the minimum required version of CMake to match DeviutionX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.22)
 project(zt)
 find_package(Threads)
 


### PR DESCRIPTION
Fixes the error with the MSVC build.

> CMake Error at build-ninja-vcpkg-relwithdebinfo/_deps/libzt-src/CMakeLists.txt:1 (cmake_minimum_required):
Error:   Compatibility with CMake < 3.5 has been removed from CMake.

We could target 3.5, but I figure there's not much point given DevilutionX requires a much higher version anyway.